### PR TITLE
Hechas mejoras en la pantalla agregar transaccion

### DIFF
--- a/App/app/src/main/java/com/afundacion/gestorfinanzasdesarrollointerfaces/Screens/Transaction.java
+++ b/App/app/src/main/java/com/afundacion/gestorfinanzasdesarrollointerfaces/Screens/Transaction.java
@@ -1,7 +1,10 @@
 package com.afundacion.gestorfinanzasdesarrollointerfaces.Screens;
 
+import android.app.DatePickerDialog;
 import android.content.Context;
 import android.os.Bundle;
+import android.text.InputFilter;
+import android.text.Spanned;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -9,6 +12,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
+import android.widget.DatePicker;
 import android.widget.EditText;
 import android.widget.Spinner;
 import android.widget.Toast;
@@ -18,6 +22,7 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
 import com.afundacion.gestorfinanzasdesarrollointerfaces.R;
+import com.afundacion.gestorfinanzasdesarrollointerfaces.Utils.DatePickerFragment;
 import com.android.volley.Request;
 import com.android.volley.RequestQueue;
 import com.android.volley.Response;
@@ -27,6 +32,9 @@ import com.android.volley.toolbox.Volley;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import java.text.DecimalFormatSymbols;
+import java.util.Calendar;
 
 public class Transaction extends Fragment {
 
@@ -57,13 +65,53 @@ public class Transaction extends Fragment {
         descripcion = view.findViewById(R.id.Descripcion);
         cantidad = view.findViewById(R.id.Cantidad);
         fecha = view.findViewById(R.id.Fecha);
+        fecha.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                showDatePickerDialog();
+            }
+        });
+        final Calendar c = Calendar.getInstance();
+        int year = c.get(Calendar.YEAR);
+        int month = c.get(Calendar.MONTH);
+        int day = c.get(Calendar.DAY_OF_MONTH);
+
+        fecha.setText(twoDigits(day) + "/" + twoDigits(month + 1) + "/" + year);
+        cantidad.setFilters(new InputFilter[]{new InputFilter() {
+
+            DecimalFormatSymbols decimalFormatSymbols = new DecimalFormatSymbols();
+
+            @Override
+            public CharSequence filter(CharSequence source, int start, int end, Spanned dest, int dstart, int dend) {
+                int indexPoint = dest.toString().indexOf(decimalFormatSymbols.getDecimalSeparator());
+
+                if (indexPoint == -1)
+                    return source;
+
+                int decimals = dend - (indexPoint+1);
+                return decimals < 2 ? source : "";
+            }
+        }
+        });
 
         submitButton = view.findViewById(R.id.submit);
         submitButton.setOnClickListener(new View.OnClickListener() {
 
             @Override
             public void onClick(View view) {
-                newTransaction();
+                if (cantidad.length() == 0){
+                    cantidad.setError("Falta Cantidad");
+                }
+                if (descripcion.length() == 0){
+                    descripcion.setError("Falta descripción");
+                }
+                if (fecha.length() == 0){
+                    fecha.setError("Falta fecha");
+                }
+                if (cantidad.getError() == null && descripcion.getError() == null && fecha.getError() == null){
+                    newTransaction();
+                }
+
             }
         });
 
@@ -97,7 +145,13 @@ public class Transaction extends Fragment {
                     @Override
                     public void onResponse(JSONObject response) {
                         Toast.makeText(context, "Nueva transacción creada con éxito", Toast.LENGTH_SHORT).show();
-                        //finish();
+                        cantidad.setText("");
+                        descripcion.setText("");
+                        final Calendar c = Calendar.getInstance();
+                        int year = c.get(Calendar.YEAR);
+                        int month = c.get(Calendar.MONTH);
+                        int day = c.get(Calendar.DAY_OF_MONTH);
+                        fecha.setText(twoDigits(day) + "/" + twoDigits(month + 1) + "/" + year);
                     }
                 },
 
@@ -115,4 +169,20 @@ public class Transaction extends Fragment {
         );
         this.requestQueue.add(request);
     }
+    private void showDatePickerDialog() {
+        DatePickerFragment newFragment = DatePickerFragment.newInstance(new DatePickerDialog.OnDateSetListener() {
+            @Override
+            public void onDateSet(DatePicker datePicker, int year, int month, int day) {
+                final String selectedDate = twoDigits(day) + "/" + twoDigits(month + 1) + "/" + year ;
+                fecha.setText(selectedDate);
+            }
+        });
+        //Cuando sea un fragment antes del getSupport hay que poner un getActivity()
+        newFragment.show(getActivity().getSupportFragmentManager(), "datePicker");
+    }
+    private String twoDigits(int n) {
+        return (n<=9) ? ("0"+n) : String.valueOf(n);
+    }
 }
+
+

--- a/App/app/src/main/java/com/afundacion/gestorfinanzasdesarrollointerfaces/Utils/DatePickerFragment.java
+++ b/App/app/src/main/java/com/afundacion/gestorfinanzasdesarrollointerfaces/Utils/DatePickerFragment.java
@@ -1,0 +1,38 @@
+package com.afundacion.gestorfinanzasdesarrollointerfaces.Utils;
+
+import android.app.DatePickerDialog;
+import android.app.Dialog;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.DialogFragment;
+
+import java.util.Calendar;
+
+public class DatePickerFragment extends DialogFragment {
+    private DatePickerDialog.OnDateSetListener listener;
+
+    public static DatePickerFragment newInstance(DatePickerDialog.OnDateSetListener listener) {
+        DatePickerFragment fragment = new DatePickerFragment();
+        fragment.setListener(listener);
+        return fragment;
+    }
+
+    public void setListener(DatePickerDialog.OnDateSetListener listener) {
+        this.listener = listener;
+    }
+
+    @Override
+    @NonNull
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        final Calendar c = Calendar.getInstance();
+        int year = c.get(Calendar.YEAR);
+        int month = c.get(Calendar.MONTH);
+        int day = c.get(Calendar.DAY_OF_MONTH);
+
+        DatePickerDialog dialog = new DatePickerDialog(getActivity(), listener, year, month, day);
+        dialog.getDatePicker().setMaxDate(System.currentTimeMillis());
+        return dialog;
+
+    }
+}

--- a/App/app/src/main/res/layout/activity_transaction_screen.xml
+++ b/App/app/src/main/res/layout/activity_transaction_screen.xml
@@ -71,6 +71,8 @@
         android:layout_marginTop="45dp"
         android:maxLength="10"
         android:hint="Fecha"
+        android:focusable="false"
+        android:clickable="true"
         android:inputType="date"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
# Arreglos

- Cuando acabas de hacer una transacción se borra los campos para que puedas hacer otra
- Datepicker agregado al edittext "Fecha" y puesta como predefinida la fecha actual
- Cantidad solo puede tener dos números decimales
- Restricciones añadidas a los 3 edittext(no pueden estar vacíos)
- Si hay algún error en un campo, no deja hacer la transacción